### PR TITLE
Change 'fig.show' to 'plt.show'

### DIFF
--- a/ex_surface01.py
+++ b/ex_surface01.py
@@ -40,6 +40,6 @@ surfplt = ax.plot_trisurf(surfpts_x, surfpts_y, surfpts_z, cmap=plt.cm.viridis) 
 ax.set_xlim(-25, 25)
 ax.set_ylim(-25, 25)
 ax.set_zlim(-15, 15)
-fig.show()
+plt.show()
 
 print("End of NURBS-Python Example")

--- a/ex_surface02.py
+++ b/ex_surface02.py
@@ -52,6 +52,6 @@ surfplt = ax.plot_trisurf(surfpts_x, surfpts_y, surfpts_z, cmap=plt.cm.winter)  
 ax.set_xlim(-25, 25)
 ax.set_ylim(-25, 25)
 ax.set_zlim(-15, 15)
-fig.show()
+plt.show()
 
 print("End of NURBS-Python Example")

--- a/ex_surface03.py
+++ b/ex_surface03.py
@@ -43,6 +43,6 @@ surfplt = ax.scatter(surfpts_x, surfpts_y, surfpts_z, c="green", s=10, depthshad
 ax.set_xlim(-2, 2)
 ax.set_ylim(-2, 2)
 ax.set_zlim(-1, 1)
-fig.show()
+plt.show()
 
 print("End of NURBS-Python Example")


### PR DESCRIPTION
Some figures disappeared immediately.
Online sources (e.g. [this one](https://stackoverflow.com/questions/12369693/how-to-make-the-plot-not-disappear)) suggest replacing `fig.show()` by `plt.show()`, which worked for me as well. The `fig.show()` call only worked for me in interactive python session.