### PR TITLE
Replace basestring with str

### DIFF
--- a/nurbs/Grid.py
+++ b/nurbs/Grid.py
@@ -205,7 +205,7 @@ class Grid:
         if not self._gridpts:
             raise ValueError("Grid must be generated before saving it to a file!")
 
-        if not isinstance(file_name, basestring):
+        if not isinstance(file_name, str):
             raise ValueError("File name must be a string!")
 
         # Open the file for writing


### PR DESCRIPTION
The `ex_grid01.py` did not work in `python3`. This should be the way to fix it (https://docs.python.org/3/whatsnew/3.0.html?highlight=basestring).