### PR TITLE
migrate to use ABCMeta for type checking - in lieu of duck typing or …

### DIFF
--- a/geomdl/BSpline.py
+++ b/geomdl/BSpline.py
@@ -488,7 +488,7 @@ class Surface(abstract.Surface):
 
     @ctrlpts2d.setter
     def ctrlpts2d(self, value):
-        if not isinstance(value, (list, tuple)):
+        if not isinstance(value, abstract.GeomdlSequence):
             raise ValueError("The input must be a list or tuple")
 
         # Clean up the surface and control points

--- a/geomdl/CPGen.py
+++ b/geomdl/CPGen.py
@@ -10,7 +10,7 @@
 import random
 import warnings
 from ._utilities import export
-
+from . import abstract
 
 @export
 class Grid(object):
@@ -155,7 +155,7 @@ class Grid(object):
             warnings.warn("Number of bumps must be an integer value. Automatically rounding to %d" % num_bumps,
                           UserWarning)
 
-        if isinstance(bump_height, (list, tuple)):
+        if isinstance(bump_height, abstract.GeomdlSequence):
             if len(bump_height) != num_bumps:
                 raise ValueError("Number of bump heights must be equal to number of bumps")
             else:
@@ -286,7 +286,7 @@ class GridWeighted(Grid):
             if value <= 0:
                 raise ValueError("Weight value must be bigger than 0")
             self._weights = [float(value) for _ in range(len(self))]
-        elif isinstance(value, (list, tuple)):
+        elif isinstance(value, abstract.GeomdlSequence):
             if len(value) != len(self):
                 raise ValueError("Input must be the same size with the grid points")
             if all(val <= 0 for val in value):

--- a/geomdl/abstract.py
+++ b/geomdl/abstract.py
@@ -11,11 +11,24 @@ import copy
 import abc
 import warnings
 from . import vis, helpers, knotvector, voxelize, utilities
-from . import tessellate
+from . import tessellate, abstract
 from .evaluators import AbstractEvaluator
 from .exceptions import GeomdlException
 from . import _utilities as utl
 
+@utl.add_metaclass(abc.ABCMeta)
+class GeomdlSequence(object):
+    """ Abstract base for supported input types
+
+    This class allows extensibility for registering additional input types
+    e.g.
+
+    import numpy as np
+    GeomdlSequence.register(np.ndarray)
+    """
+
+GeomdlSequence.register(list)
+GeomdlSequence.register(tuple)
 
 @utl.add_metaclass(abc.ABCMeta)
 class GeomdlBase(object):
@@ -170,7 +183,7 @@ class GeomdlBase(object):
 
     @opt.setter
     def opt(self, key_value):
-        if not isinstance(key_value, (list, tuple)):
+        if not isinstance(key_value, abstract.GeomdlSequence):
             raise GeomdlException("opt input must be a list or a tuple")
         if len(key_value) != 2:
             raise GeomdlException("opt input must have a size of 2, corresponding to [0:key] => [1:value]")
@@ -1275,7 +1288,7 @@ class Surface(SplineGeometry):
 
     @degree.setter
     def degree(self, value):
-        if not isinstance(value, (list, tuple)):
+        if not isinstance(value, abstract.GeomdlSequence):
             raise ValueError("Please input a list with a length of " + str(self.pdimension))
         self.degree_u = value[0]
         self.degree_v = value[1]
@@ -1338,7 +1351,7 @@ class Surface(SplineGeometry):
 
     @knotvector.setter
     def knotvector(self, value):
-        if not isinstance(value, (list, tuple)):
+        if not isinstance(value, abstract.GeomdlSequence):
             raise ValueError("Please input a list with a length of " + str(self.pdimension))
         self.knotvector_u = value[0]
         self.knotvector_v = value[1]
@@ -1670,7 +1683,7 @@ class Surface(SplineGeometry):
         if isinstance(value, (int, float)):
             self.delta_u = value
             self.delta_v = value
-        elif isinstance(value, (list, tuple)):
+        elif isinstance(value, abstract.GeomdlSequence):
             if len(value) == 2:
                 self.delta_u = value[0]
                 self.delta_v = value[1]
@@ -1759,7 +1772,7 @@ class Surface(SplineGeometry):
     @trims.setter
     def trims(self, value):
         # Input type validation
-        if not isinstance(value, (list, tuple)):
+        if not isinstance(value, abstract.GeomdlSequence):
             raise GeomdlException("'trims' setter only accepts a list or a tuple containing the trimming curves")
         # Trim curve validation
         for i, v in enumerate(value):
@@ -2246,7 +2259,7 @@ class Volume(SplineGeometry):
 
     @degree.setter
     def degree(self, value):
-        if not isinstance(value, (list, tuple)):
+        if not isinstance(value, abstract.GeomdlSequence):
             raise ValueError("Please input a list with a length of " + str(self.pdimension))
         self.degree_u = value[0]
         self.degree_v = value[1]
@@ -2333,7 +2346,7 @@ class Volume(SplineGeometry):
 
     @knotvector.setter
     def knotvector(self, value):
-        if not isinstance(value, (list, tuple)):
+        if not isinstance(value, abstract.GeomdlSequence):
             raise ValueError("Please input a list with a length of " + str(self.pdimension))
         self.knotvector_u = value[0]
         self.knotvector_v = value[1]
@@ -2783,7 +2796,7 @@ class Volume(SplineGeometry):
             self.delta_u = value
             self.delta_v = value
             self.delta_w = value
-        elif isinstance(value, (list, tuple)):
+        elif isinstance(value, abstract.GeomdlSequence):
             if len(value) == 3:
                 self.delta_u = value[0]
                 self.delta_v = value[1]
@@ -2808,7 +2821,7 @@ class Volume(SplineGeometry):
     @trims.setter
     def trims(self, value):
         # Input type validation
-        if not isinstance(value, (list, tuple)):
+        if not isinstance(value, abstract.GeomdlSequence):
             raise GeomdlException("'trims' setter only accepts a list or a tuple containing the trimming surfaces")
         # Trim curve validation
         for i, v in enumerate(value):

--- a/geomdl/control_points.py
+++ b/geomdl/control_points.py
@@ -12,6 +12,7 @@ import copy
 from functools import reduce
 from .exceptions import GeomdlException
 from ._utilities import export, add_metaclass
+from . import abstract
 
 
 @add_metaclass(abc.ABCMeta)
@@ -129,7 +130,7 @@ class AbstractManager(object):
         :param pt: control point
         :type pt: list, tuple
         """
-        if not isinstance(pt, (list, tuple)):
+        if not isinstance(pt, abstract.GeomdlSequence):
             raise GeomdlException("'pt' argument should be a list or tuple")
         if len(args) != len(self._size):
             raise GeomdlException("Input dimensions are not compatible with the geometry")
@@ -169,7 +170,7 @@ class AbstractManager(object):
         try:
             for k, val in adct.items():
                 if k in self._pt_data:
-                    if isinstance(val, (list, tuple)):
+                    if isinstance(val, abstract.GeomdlSequence):
                         for j, v in enumerate(val):
                             self._pt_data[k][idx][j] = v
                     else:

--- a/geomdl/elements.py
+++ b/geomdl/elements.py
@@ -11,6 +11,7 @@ import copy
 import abc
 from .exceptions import GeomdlException
 from . import _utilities as utl
+from . import abstract
 
 
 @utl.add_metaclass(abc.ABCMeta)
@@ -163,7 +164,7 @@ class AbstractEntity(object):
 
     @opt.setter
     def opt(self, key_value):
-        if not isinstance(key_value, (list, tuple)):
+        if not isinstance(key_value, abstract.GeomdlSequence):
             raise GeomdlException("opt input must be a list or a tuple")
         if len(key_value) != 2:
             raise GeomdlException("opt input must have a size of 2, corresponding to [0:key] => [1:value]")
@@ -337,7 +338,7 @@ class Vertex(AbstractEntity):
 
     @uv.setter
     def uv(self, value):
-        if not isinstance(value, (list, tuple)):
+        if not isinstance(value, abstract.GeomdlSequence):
             raise GeomdlException("UV data input must be a list or tuple")
         if len(value) != 2:
             raise GeomdlException("UV must have 2 components")
@@ -368,7 +369,7 @@ class Vertex(AbstractEntity):
 
     @data.setter
     def data(self, value):
-        if not isinstance(value, (list, tuple)):
+        if not isinstance(value, abstract.GeomdlSequence):
             raise GeomdlException("Vertex data must be a list or tuple")
         if len(value) != 3:
             raise GeomdlException("Vertex can only store 3 components")
@@ -473,7 +474,7 @@ class Triangle(AbstractEntity):
 
     @data.setter
     def data(self, value):
-        if not isinstance(value, (list, tuple)):
+        if not isinstance(value, abstract.GeomdlSequence):
             raise GeomdlException("Input must be a list or tuple")
         if len(value) != 3:
             raise GeomdlException("Triangle can only have 3 vertices")
@@ -528,7 +529,7 @@ class Quad(AbstractEntity):
 
     @data.setter
     def data(self, value):
-        if not isinstance(value, (list, tuple)):
+        if not isinstance(value, abstract.GeomdlSequence):
             raise GeomdlException("Input must be a list or tuple")
         if len(value) != 4:
             raise GeomdlException("Quad can only have 4 vertices")

--- a/geomdl/fitting.py
+++ b/geomdl/fitting.py
@@ -8,7 +8,7 @@
 """
 
 import math
-from . import BSpline, helpers, linalg
+from . import BSpline, helpers, linalg, abstract
 from ._utilities import export
 
 
@@ -430,7 +430,7 @@ def compute_params_curve(points, centripetal=False):
     :return: parameter array, :math:`\\overline{u}_{k}`
     :rtype: list
     """
-    if not isinstance(points, (list, tuple)):
+    if not isinstance(points, abstract.GeomdlSequence):
         raise TypeError("Data points must be a list or a tuple")
 
     # Length of the points array

--- a/geomdl/linalg.py
+++ b/geomdl/linalg.py
@@ -12,7 +12,7 @@ import math
 from copy import deepcopy
 from functools import reduce
 from .exceptions import GeomdlException
-from . import _linalg
+from . import _linalg, abstract
 try:
     from functools import lru_cache
 except ImportError:
@@ -270,7 +270,7 @@ def vector_is_zero(vector_in, tol=10e-8):
     :return: True if the input vector is zero, False otherwise
     :rtype: bool
     """
-    if not isinstance(vector_in, (list, tuple)):
+    if not isinstance(vector_in, abstract.GeomdlSequence):
         raise TypeError("Input vector must be a list or a tuple")
 
     res = [False for _ in range(len(vector_in))]

--- a/geomdl/multi.py
+++ b/geomdl/multi.py
@@ -187,7 +187,7 @@ class AbstractContainer(abstract.GeomdlBase):
         if self._pdim == 1 and isinstance(value, (int, float)):
             delta_vals = [value]
         else:
-            if isinstance(value, (list, tuple)):
+            if isinstance(value, abstract.GeomdlSequence):
                 if len(value) != self._pdim:
                     raise ValueError("The input must be a list of a tuple with a length of " + str(self._pdim))
                 delta_vals = value
@@ -236,7 +236,7 @@ class AbstractContainer(abstract.GeomdlBase):
         if self._pdim == 1 and isinstance(value, (int, float)):
             ssz = [value]
         else:
-            if isinstance(value, (list, tuple)):
+            if isinstance(value, abstract.GeomdlSequence):
                 if len(value) != self._pdim:
                     raise ValueError("The input must be a list of a tuple with a length of " + str(self._pdim))
                 ssz = value
@@ -400,13 +400,13 @@ class CurveContainer(AbstractContainer):
         reset_names = kwargs.get('reset_names', False)
 
         # Check if the input list sizes are equal
-        if isinstance(cpcolor, (list, tuple)):
+        if isinstance(cpcolor, abstract.GeomdlSequence):
             if len(cpcolor) < len(self._elements):
                 raise ValueError("The number of color values in 'cpcolor' (" + str(len(cpcolor)) +
                                  ") cannot be less than the number of geometries contained ("
                                  + str(len(self._elements)) + ")")
 
-        if isinstance(evalcolor, (list, tuple)):
+        if isinstance(evalcolor, abstract.GeomdlSequence):
             if len(evalcolor) < len(self._elements):
                 raise ValueError("The number of color values in 'evalcolor' (" + str(len(evalcolor)) +
                                  ") cannot be less than the number of geometries contained ("
@@ -765,13 +765,13 @@ class SurfaceContainer(AbstractContainer):
         force_tsl = bool(kwargs.pop('force', False))  # flag to force re-tessellation
 
         # Check if the input list sizes are equal
-        if isinstance(cpcolor, (list, tuple)):
+        if isinstance(cpcolor, abstract.GeomdlSequence):
             if len(cpcolor) != len(self._elements):
                 raise ValueError("The number of colors in 'cpcolor' (" + str(len(cpcolor)) +
                                  ") cannot be less than the number of geometries contained(" +
                                  str(len(self._elements)) + ")")
 
-        if isinstance(evalcolor, (list, tuple)):
+        if isinstance(evalcolor, abstract.GeomdlSequence):
             if len(evalcolor) != len(self._elements):
                 raise ValueError("The number of colors in 'evalcolor' (" + str(len(evalcolor)) +
                                  ") cannot be less than the number of geometries contained ("
@@ -779,7 +779,7 @@ class SurfaceContainer(AbstractContainer):
 
         # Get colormaps as a list
         surf_cmaps = kwargs.get('colormap', [])
-        if not isinstance(surf_cmaps, (list, tuple)):
+        if not isinstance(surf_cmaps, abstract.GeomdlSequence):
             warnings.warn("Expecting a list of colormap values, not " + str(type(surf_cmaps)))
             surf_cmaps = []
 
@@ -1032,13 +1032,13 @@ class VolumeContainer(AbstractContainer):
         reset_names = kwargs.get('reset_names', False)
 
         # Check if the input list sizes are equal
-        if isinstance(cpcolor, (list, tuple)):
+        if isinstance(cpcolor, abstract.GeomdlSequence):
             if len(cpcolor) != len(self._elements):
                 raise ValueError("The number of colors in 'cpcolor' (" + str(len(cpcolor)) +
                                  ") cannot be less than the number of geometries contained(" +
                                  str(len(self._elements)) + ")")
 
-        if isinstance(evalcolor, (list, tuple)):
+        if isinstance(evalcolor, abstract.GeomdlSequence):
             if len(evalcolor) != len(self._elements):
                 raise ValueError("The number of colors in 'evalcolor' (" + str(len(evalcolor)) +
                                  ") cannot be less than the number of geometries contained ("
@@ -1106,7 +1106,7 @@ def select_color(cpcolor, evalcolor, idx=0):
         color[0] = cpcolor
 
     # User-defined color for control points grid
-    if isinstance(cpcolor, (list, tuple)):
+    if isinstance(cpcolor, abstract.GeomdlSequence):
         color[0] = cpcolor[idx]
 
     # Constant color for evaluated points grid
@@ -1114,7 +1114,7 @@ def select_color(cpcolor, evalcolor, idx=0):
         color[1] = evalcolor
 
     # User-defined color for evaluated points grid
-    if isinstance(evalcolor, (list, tuple)):
+    if isinstance(evalcolor, abstract.GeomdlSequence):
         color[1] = evalcolor[idx]
 
     return color

--- a/geomdl/operations.py
+++ b/geomdl/operations.py
@@ -54,7 +54,7 @@ def insert_knot(obj, param, num, **kwargs):
 
     if check_num:
         # Check the validity of number of insertions
-        if not isinstance(num, (list, tuple)):
+        if not isinstance(num, abstract.GeomdlSequence):
             raise GeomdlException("The number of insertions must be a list or a tuple",
                                   data=dict(num=num))
 
@@ -327,7 +327,7 @@ def remove_knot(obj, param, num, **kwargs):
 
     if check_num:
         # Check the validity of number of insertions
-        if not isinstance(num, (list, tuple)):
+        if not isinstance(num, abstract.GeomdlSequence):
             raise GeomdlException("The number of removals must be a list or a tuple",
                                   data=dict(num=num))
 
@@ -623,7 +623,7 @@ def refine_knotvector(obj, param, **kwargs):
     check_num = kwargs.get('check_num', True)  # enables/disables input validity checks
 
     if check_num:
-        if not isinstance(param, (list, tuple)):
+        if not isinstance(param, abstract.GeomdlSequence):
             raise GeomdlException("Parametric dimensions argument (param) must be a list or a tuple")
 
         if len(param) != obj.pdimension:
@@ -1405,7 +1405,7 @@ def tangent(obj, params, **kwargs):
     """
     normalize = kwargs.get('normalize', True)
     if isinstance(obj, abstract.Curve):
-        if isinstance(params, (list, tuple)):
+        if isinstance(params, abstract.GeomdlSequence):
             return ops.tangent_curve_single_list(obj, params, normalize)
         else:
             return ops.tangent_curve_single(obj, params, normalize)
@@ -1432,7 +1432,7 @@ def normal(obj, params, **kwargs):
     """
     normalize = kwargs.get('normalize', True)
     if isinstance(obj, abstract.Curve):
-        if isinstance(params, (list, tuple)):
+        if isinstance(params, abstract.GeomdlSequence):
             return ops.normal_curve_single_list(obj, params, normalize)
         else:
             return ops.normal_curve_single(obj, params, normalize)
@@ -1459,7 +1459,7 @@ def binormal(obj, params, **kwargs):
     """
     normalize = kwargs.get('normalize', True)
     if isinstance(obj, abstract.Curve):
-        if isinstance(params, (list, tuple)):
+        if isinstance(params, abstract.GeomdlSequence):
             return ops.binormal_curve_single_list(obj, params, normalize)
         else:
             return ops.binormal_curve_single(obj, params, normalize)

--- a/geomdl/ray.py
+++ b/geomdl/ray.py
@@ -7,9 +7,8 @@
 
 """
 
-from . import linalg
+from . import linalg, abstract
 from ._utilities import export
-
 
 @export
 class Ray(object):
@@ -26,9 +25,9 @@ class Ray(object):
     """
     def __init__(self, point1, point2):
         super(Ray, self).__init__()
-        if not isinstance(point1, (list, tuple)):
+        if not isinstance(point1, abstract.GeomdlSequence):
             raise TypeError("Point 1 must be a list or a tuple")
-        if not isinstance(point2, (list, tuple)):
+        if not isinstance(point2, abstract.GeomdlSequence):
             raise TypeError("Point 2 must be a list or a tuple")
         if len(point1) != len(point2):
             raise ValueError("THe dimensions of the input points must be equal")


### PR DESCRIPTION
…explicit type checking

I've precalculation code in numpy, but notice you don't want to directly support numpy.  So, perhaps a more flexible solution is to use the standard library ABC - as proposed in this PR