### PR TITLE
ray intersect tolerance workaround

### DIFF
--- a/geomdl/ray.py
+++ b/geomdl/ray.py
@@ -6,6 +6,7 @@
 .. moduleauthor:: Onur Rauf Bingol <orbingol@gmail.com>
 
 """
+import sys
 
 from . import linalg
 from ._utilities import export
@@ -139,7 +140,7 @@ def intersect(ray1, ray2, **kwargs):
         raise ValueError("Dimensions of the input rays must be the same")
 
     # Keyword arguments
-    tol = kwargs.get('tol', 10e-17)
+    tol = kwargs.get('tol', (1 << 8) * sys.float_info.epsilon)
 
     # Call intersection method
     if ray1.dimension == 2:

--- a/tests/test_ray.py
+++ b/tests/test_ray.py
@@ -1,0 +1,11 @@
+import pytest
+
+from geomdl import ray
+from geomdl.ray import Ray, RayIntersection
+
+def test_ray_intersect():
+    r2 = Ray((5.0, 181.34), (13.659999999999997, 176.34))
+    r3 = Ray((19.999779996773235, 189.9998729810778), (19.999652977851035, 180.00009298430456))
+    t0, t1, res = ray.intersect(r2, r3)
+    assert res != RayIntersection.SKEW
+


### PR DESCRIPTION
ref issue #57

The points / vectors are sampled from some tangent vectors around an arc.  Arises when subdividing an arc for deriving control points for a spline representation.  It may be possible to reproduce the same problem by taking advantage of the FP representation of certain decimal numbers.

The result bounds (at double precision) can be improved by moving to use additional basic operations (adding by parts, math.fsum and improve dot / cross algorithms).  Extended precision would be better, but I think it's not available without additional libraries.  I may make additional PR.

I label this a workaround, because I'm not satisfied with the required tolerance.