### PR TITLE
Remove redundant basepython settings

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,14 +18,6 @@ skip_missing_interpreters = {env:TOX_SKIP_MISSING_INTERPRETERS:True}
 
 # Default test environment
 [testenv]
-basepython =
-    py27: python2.7
-    py34: python3.4
-    py35: python3.5
-    py36: python3.6
-    py37: python3.7
-    pypy3: pypy3
-
 setenv =
     MPLBACKEND = Agg
 


### PR DESCRIPTION
It's automatic, see https://tox.wiki/en/latest/config.html#conf-basepython

They are more possible improvements for tox.ini and the Python project metadata itself. Let me know whether you are interested in them.